### PR TITLE
file_processing_project#1

### DIFF
--- a/project#1/copy.c
+++ b/project#1/copy.c
@@ -1,0 +1,30 @@
+#include <stdio.h>
+#include <fcntl.h>
+#include <unistd.h>
+int main(int argc, char *argv[]){
+	if (argc != 3){
+		fprintf(stderr,"잘못된 형식입니다.\n");
+		return 0;
+	}
+    int fd1 = open(argv[1], O_RDONLY);
+	if(fd1==-1){
+        fprintf(stderr,"파일 열기 실패\n");
+        return 0;
+    }
+    int fd2 = open(argv[2],O_WRONLY | O_TRUNC | O_CREAT,0644);
+    if (fd2 == -1) {
+        fprintf(stderr, "복사본 생성 실패\n");
+        close(fd1);
+        return 0;
+    }
+    
+    int read_bytes = 0;
+    char buffer[10];
+    //read_bytes에 읽은 bytes 수를 기록하여 읽은크기만큼만 쓰기
+    while((read_bytes = read(fd1, buffer, 10)) > 0){
+        write(fd2, buffer,read_bytes);
+    }
+
+    close(fd1);
+    close(fd2);
+}

--- a/project#1/delete.c
+++ b/project#1/delete.c
@@ -1,0 +1,37 @@
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <fcntl.h>
+int main(int argc, char* argv[]){
+    if(argc != 4){
+        fprintf(stderr, "잘못된 형식입니다.\n");
+        return 0;
+    }
+    int fd = open(argv[3], O_RDWR);
+    if(fd==-1){
+        fprintf(stderr,"파일을 열지 못했습니다.\n");
+        return 0;
+    }   
+
+    long file_size = lseek(fd,0,2);
+    long offset = atoi(argv[1]);
+    long byte_size = atoi(argv[2]);
+    if(file_size < offset+byte_size){
+        //지우려는 바이트수가 남이있는 파일보다 클 때
+        byte_size = file_size - offset;
+    }
+    long copy_size = file_size - offset - byte_size;
+    char *buffer = (char *)malloc(copy_size);
+    if(offset>file_size){
+        fprintf(stderr, "offset이 file크기보다 큽니다.\n");
+        return 0;
+    }
+    lseek(fd, offset + byte_size, 0);
+    copy_size = read(fd, buffer, copy_size);
+    lseek(fd, offset, 0);
+    write(fd, buffer, copy_size);
+    ftruncate(fd, file_size - byte_size);
+    free(buffer);
+    close(fd);
+}

--- a/project#1/insert.c
+++ b/project#1/insert.c
@@ -1,0 +1,32 @@
+#include <stdio.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <string.h>
+#include <stdlib.h>
+int main(int argc, char *argv[]){
+    if(argc != 4){
+        fprintf(stderr,"잘못된 형식입니다.\n");
+        return 0;
+    }
+    int fd = open(argv[3], O_RDWR);
+    if(fd==-1){ 
+        fprintf(stderr,"파일을 열지 못했습니다.\n");
+        return 0;
+    }
+    long offset = atol(argv[1]);
+    long file_size = lseek(fd,0,2);
+    long copy_size = file_size - offset - 1;
+    long data_size = strlen(argv[2]);
+    char *buffer = (char*)malloc(copy_size);
+    if(offset > file_size-1){
+        fprintf(stderr,"offset이 file크기보다 큽니다.\n");
+        return 0;
+    }
+    lseek(fd, offset+1, 0);
+    read(fd, buffer, copy_size);
+    lseek(fd, offset+1, 0);
+    write(fd, argv[2], data_size);
+    write(fd, buffer, copy_size);
+    free(buffer);
+    close(fd);
+}  

--- a/project#1/merge.c
+++ b/project#1/merge.c
@@ -1,0 +1,41 @@
+#include <stdio.h>
+#include <unistd.h>
+#include <fcntl.h>
+int main(int argc, char *argv[]){
+    char buffer[1024];  //Buffer
+    int read_bytes = 0; //읽기 성공한 바이트수
+    if(argc != 4){
+        fprintf(stderr,"잘못된 형식입니다\n");
+        return 0;
+    }
+    //기존에 file1이 존재할 경우 없애기 위해 O_TRUNC옵션을 준뒤
+    //close 후 O_APPEND 옵션을 적용해 다시 open
+    int fd1 = open(argv[1], O_WRONLY | O_TRUNC | O_CREAT, 0644);
+    if(fd1 ==-1){
+        fprintf(stderr, "파일 생성실패\n");
+        return 0;
+    }
+    int fd2 = open(argv[2], O_RDONLY);
+    if(fd2 ==-1){
+        fprintf(stderr, "파일 열기 실패\n");
+        return 0;
+    }
+    
+    int fd3 = open(argv[3], O_RDONLY);
+    if(fd3 ==-1){
+        fprintf(stderr, "파일 열기 실패\n");
+        return 0;
+    }
+
+    while ((read_bytes = read(fd2, buffer, 1024)) > 0){
+        write(fd1, buffer, read_bytes);
+    }
+    close(fd1);
+    fd1 = open(argv[1], O_WRONLY | O_APPEND);
+    while ((read_bytes = read(fd3, buffer, 1024)) > 0){
+        write(fd1, buffer, read_bytes);
+    }
+    close(fd1);
+    close(fd2);
+    close(fd3);
+}

--- a/project#1/read.c
+++ b/project#1/read.c
@@ -1,0 +1,31 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <fcntl.h>
+#define buffer_size 1024
+int main(int argc, char *argv[]){
+    char buffer[buffer_size];
+    long read_bytes = 0;
+    long total_bytes = 0;
+    if(argc != 4){
+        fprintf(stderr, "잘못된 형식입니다.\n");
+        return 0;  
+    }
+    int fd = open(argv[3], O_RDONLY);
+    if(fd==-1){
+        fprintf(stderr,"파일을 열지 못했습니다.\n");
+        return 0;
+    }
+    lseek(fd, atol(argv[1]),0);
+    while(total_bytes < atol(argv[2]) && (read_bytes = read(fd, buffer, buffer_size))>0){
+        if(atol(argv[2]) > (total_bytes + read_bytes)){
+            write(1, buffer, read_bytes);
+            total_bytes += read_bytes;
+        }
+        else{
+            write(1, buffer, atol(argv[2])-total_bytes);
+            total_bytes += read_bytes;
+        }
+    }
+    close(fd);
+}

--- a/project#1/write.c
+++ b/project#1/write.c
@@ -1,0 +1,35 @@
+#include <stdio.h>
+#include <string.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <stdlib.h>
+#define buffer_size 1024
+int main(int argc, char *argv[]){
+    char buffer[buffer_size];
+    if(argc != 4){
+        fprintf(stderr,"잘못된 형식입니다/\n");
+        return 0;
+    }
+    int fd = open(argv[3], O_WRONLY);
+    if(fd == -1){
+        fprintf(stderr, "파일을 열지 못했습니다.\n");
+        return 0;
+    }
+    lseek(fd,atol(argv[1]),0);
+    long data_size = strlen(argv[2]);
+    long total_bytes = 0;
+    
+    while(data_size > total_bytes){
+        if(data_size-total_bytes <= buffer_size){
+            memcpy(buffer, argv[2] + total_bytes, data_size - total_bytes);
+            write(fd,buffer,data_size-total_bytes);
+            total_bytes = data_size;
+        }
+        else{
+            memcpy(buffer, argv[2] + total_bytes, buffer_size);
+            write(fd, buffer, buffer_size);
+            total_bytes += buffer_size;
+        }
+    }
+    close(fd);
+}


### PR DESCRIPTION
## 과제 1: 파일 I/O 연산 활용

아래의 기능들을 수행하는 프로그램을 구현하며, 다음과 같은 제약 사항들을 따른다.
- 파일의 데이터는 아라비아 숫자와 영어 알파벳만으로 표현되며, 터미널 상에서 사용자 입력으로 주어지는 데이터도 이 조건을 따른다.
- 파일 I/O 연산은 system call 또는 C 라이브러리만을 사용한다.

### (1) 복사: copy.c 작성
이미 존재하는 원본파일로부터 10바이트 단위로 데이터를 읽어 새로운 복사본파일에 저장한다. 마지막으로 복사할 데이터가 10바이트가 되지 않는 경우 그 크기만큼의 데이터를 읽어 복사본파일에 저장한다. 만약 명령어를 수행 시 복사본파일이 존재하면 파일의 데이터를 모두 삭제한 후(즉, 그 크기를 0으로 만든 후) 원본파일의 데이터를 복사해야 한다. 복사본파일이 존재하지 않으면 새로 생성해야 하며, 명령어를 실행한 후 복사본파일의 내용은 항상 원본파일의 것과 동일해야 한다.
    
a.out <원본파일명> <복사본파일명>

### (2) 병합하기(merge): merge.c 작성
새로운 파일 <파일1>에 이미 존재하는 두 개의 파일, <파일2>과 <파일3>의 데이터를 병합하여 저장한다. 병합의 순서는 <파일2>과 <파일3>의 순서를 따르며, <파일1>의 크기는 병합하려는 두 개의 파일의 크기의 합과 정확히 일치해야 한다.

a.out <파일명1> <파일명2> <파일명3>

### (3) 읽기: read.c 작성
이미 존재하는 파일에서 <오프셋(offset= 0, 1, 2, ...)>을 포함한 오른편에 존재하는 <바이트 수>만큼의 데이터를 읽어서 화면에 출력한다. <바이트 수>가 0이면 데이터를 읽을 필요가 없으며 당연히 화면에 출력되는 데이터도 존재하지 않는다. <바이트 수>만큼의 읽을 데이터가 존재하지 않으면 존재하는 데이터만큼만 읽으면 된다. 예를 들면, 파일의 크기가 30바이트, <오프셋>이 10, <바이트 수>가 5이면 오프셋 10부터 14까지 데이터를 읽어서 출력한다.

a.out <오프셋> <바이트 수> <파일명>

### (4) 쓰기: write.c 작성
이미 존재하는 파일에서 주어진 <오프셋(=0, 1, 2, ...)> 위치부터 주어진 데이터를 덮어쓴다. 덮어쓰기를 할 때 파일의 EOF를 만나면 중단하지 않고 그대로 쓰기를 진행한다. <데이터>는 큰따옴표(“와 ”)로 묶어서 표현한다 (“abc”라고 입력하면 abc가 덮어쓸 데이터를 의미한다). 예를 들어, <오프셋>이 5이고 <데이터>가 “abc”라고 하면 오프셋 5, 6, 7 위치에 각각 a, b, c가 저장되어야 한다.

a.out <오프셋> <데이터> <파일명>

### (5) 끼워넣기(insert): insert.c 작성
이미 존재하는 파일에서 <오프셋(=0, 1, 2, ...)>과 <오프셋+1> 사이에 <데이터>를 끼워 넣는다. <오프셋>이 파일의 맨마지막(EOF제외)을 가리키면 append로 처리한다. <데이터>는 큰따옴표(“와 ”)로 묶어서 표현한다 (<데이터>로 “abc”라고 입력하면 abc가 끼워넣을 데이터를 의미한다). 예를 들어, <오프셋>이 7이고, <데이터>가 “abc”라고 하면 오프셋 7와 8 사이에 abc가 삽입되며, 기존의 오프셋 8을 포함한 오른편 데이터는 뒤로 밀려난다. 끼워넣기를 실행한 후 결과 파일의 크기는 기존 파일의 크기와 주어진 데이터의 크기의 합과 정확히 일치해야 한다.

a.out <오프셋> <데이터> <파일명>

### (6) 삭제하기(delete): delete.c 작성
이미 존재하는 파일에서 <오프셋(offset= 0, 1, 2, ...)>을 포함한 오른편에 존재하는 <바이트 수>만큼의 데이터를 삭제한다. <바이트 수>가 0이면 데이터를 삭제할 필요가 없다. <바이트 수>만큼 삭제할 데이터가 존재하지 않으면 존재하는 데이터만큼만 삭제하면 된다. 삭제 후 삭제 데이터를 기준으로 전후 데이터가 병합되어야 한다. 즉, 삭제 데이터만큼의 공간은 파일에서 사라져야 한다. 예를 들면, <오프셋>이 10이고 <바이트 수>가 5이면 오프셋 10부터 14까지의 공간은 사라진다. 즉, 오프셋 15를 포함한 오른편 데이터가 왼쪽으로 이동되어야 한다.

a.out <오프셋> <바이트 수> <파일명>