### PR TITLE
파일처리 프로젝트2

### DIFF
--- a/project#2/desktop.ini
+++ b/project#2/desktop.ini
@@ -1,0 +1,2 @@
+[LocalizedFileNames]
+ftlmgr.c=@ftlmgr.c,0

--- a/project#2/fdevicedriver.c
+++ b/project#2/fdevicedriver.c
@@ -1,0 +1,58 @@
+// 주의사항
+// 1. 이 파일에 어떤 함수도 추가하지 마시오.
+// 2. 이 파일에 어떤 것도 수정하지 마시오.
+// 3. 이 파일에 버그가 있으면 바로 알려 주세요.
+// 1과 2를 지키지 않으면 채점 시 컴파일이 제대로 되지 않을 수 있습니다.
+
+#include <stdio.h>
+#include <string.h>
+#include "flash.h"
+
+extern FILE *flashmemoryfp;				// ftlmgr.c에 정의되어 있음
+
+int fdd_read(int ppn, char *pagebuf)
+{
+	int ret;
+
+	fseek(flashmemoryfp, PAGE_SIZE*ppn, SEEK_SET);
+	ret = fread((void *)pagebuf, PAGE_SIZE, 1, flashmemoryfp);
+	if(ret == 1) {
+		return 1;
+	}
+	else {
+		return -1;
+	}
+}
+
+int fdd_write(int ppn, char *pagebuf)
+{
+	int ret;
+
+	fseek(flashmemoryfp, PAGE_SIZE*ppn, SEEK_SET);
+	ret = fwrite((void *)pagebuf, PAGE_SIZE, 1, flashmemoryfp);
+	if(ret == 1) {			
+		return 1;
+	}
+	else {
+		return -1;
+	}
+}
+
+int fdd_erase(int pbn)
+{
+	char blockbuf[BLOCK_SIZE];
+	int ret;
+
+	memset((void*)blockbuf, (char)0xFF, BLOCK_SIZE);
+	
+	fseek(flashmemoryfp, BLOCK_SIZE*pbn, SEEK_SET);
+	
+	ret = fwrite((void *)blockbuf, BLOCK_SIZE, 1, flashmemoryfp);
+	
+	if(ret == 1) { 
+		return 1;
+	}
+	else {
+		return -1;
+	}
+}

--- a/project#2/flash.h
+++ b/project#2/flash.h
@@ -1,0 +1,15 @@
+// 주의 사항
+// 1. 이 파일에 새로운 상수 변수를 추가 하지 마시오.
+// 2. 이 파일에 정의 되어있는 상수 변수의 이름과 값을 변경하지 마시오.
+// 1과 2를 지키지 않으면 채점 시 컴파일이 제대로 안됩니다.
+
+#ifndef	_FLASH_H_
+#define	_FLASH_H_
+
+#define	PAGE_NUM		8
+#define	SECTOR_SIZE	512			
+#define	SPARE_SIZE		16			
+#define	PAGE_SIZE	(SECTOR_SIZE+SPARE_SIZE)
+#define	BLOCK_SIZE	(PAGE_SIZE*PAGE_NUM)
+
+#endif

--- a/project#2/ftlmgr.c
+++ b/project#2/ftlmgr.c
@@ -1,0 +1,293 @@
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include "flash.h"
+// 필요한 경우 헤더파일을 추가한다
+
+FILE *flashmemoryfp;	// fdevicedriver.c에서 사용
+
+//
+// 이 함수는 FTL의 역할 중 일부분을 수행하는데 물리적인 저장장치 flash memory에 Flash device driver를 이용하여 데이터를
+// 읽고 쓰거나 블록을 소거하는 일을 한다 (강의자료 참조).
+// flash memory에 데이터를 읽고 쓰거나 소거하기 위해서 fdevicedriver.c에서 제공하는 인터페이스를
+// 호출하면 된다. 이때 해당되는 인터페이스를 호출할 때 연산의 단위를 정확히 사용해야 한다.
+// 읽기와 쓰기는 페이지 단위이며 소거는 블록 단위이다 (주의: 읽기, 쓰기, 소거를 하기 위해서는 반드시 fdevicedriver.c의 함수를 사용해야 함)
+// 갱신은 강의자료의 in-place update를 따른다고 가정한다.
+// 스페어영역에 저장되는 정수는 하나이며, 반드시 binary integer 모드로 저장해야 한다.
+//
+extern int fdd_read(int ppn, char *pagebuf);
+extern int fdd_write(int ppn, char *pagebuf);
+extern int fdd_erase(int pbn);
+int flash_memory_emulator(char *filename, int num_blocks){
+    //truncate
+    flashmemoryfp = fopen(filename, "wb");
+    if(!flashmemoryfp){
+        fprintf(stderr, "파일생성 실패\n");
+        return -1;
+    }
+    fclose(flashmemoryfp);
+    // read/write 용도
+    flashmemoryfp = fopen(filename, "rb+");
+    if(!flashmemoryfp){
+        fprintf(stderr, "파일 열기 실패\n");
+        fclose(flashmemoryfp);
+        return -1;
+    }
+    for (int i = 0  ; i < num_blocks ; i++){
+        if(fdd_erase(i)<0){
+            fprintf(stderr, "pbn : %d번 초기화 실패\n",i);
+            fclose(flashmemoryfp);
+            return -1;
+        }
+    }
+    fclose(flashmemoryfp);
+    return 0;
+}
+int ftl_write(char *flashfile, int ppn, char *sectordata, int sparedata, char buffer[]){
+    flashmemoryfp = fopen(flashfile, "rb+");
+    if(!flashmemoryfp){
+        fprintf(stderr, "파일 열기 실패\n");
+        return -1;
+    }
+    //읽고 0xFF가 아니면 이미 할당된공간
+    fdd_read(ppn, buffer);
+    for(int i = 0 ; i < PAGE_SIZE ; i++){
+        if((unsigned char)buffer[i] != 0xFF){
+            fprintf(stderr, "해당 페이지는 이미 할당되어있습니다.\n");
+            fclose(flashmemoryfp);
+            return -1;
+        }
+    }
+
+    memset(buffer, 0xFF, PAGE_SIZE);
+    int len = strlen(sectordata);
+    //sectordata 버퍼에 복사
+    memcpy(buffer, sectordata, len);
+    //spare 버퍼에 복사
+    memcpy(buffer+SECTOR_SIZE, &sparedata, sizeof(int));
+
+    if(fdd_write(ppn, buffer)<0){
+        fprintf(stderr, "쓰기에 실패했습니다.\n");
+        fclose(flashmemoryfp);
+        return -1;
+    }
+    fclose(flashmemoryfp);
+    return 0;
+}
+int ftl_read(char *flashfile, int ppn, char buffer[]){
+    flashmemoryfp = fopen(flashfile, "rb");
+    if(!flashmemoryfp){
+        fprintf(stderr,"파일 열기에 실패했습니다.\n");
+        return -1;
+    }  
+    fdd_read(ppn, buffer);
+    int checkflag = 0;
+    for(int i = 0 ; i < PAGE_SIZE ; i++){
+        if((unsigned char)buffer[i] != 0xFF){
+            checkflag = 1;
+            break;
+        }
+    }  
+    // 기록이 없을때는 아무것도 출력하지않고 종료한다.
+    if(!checkflag){
+        fclose(flashmemoryfp);
+        return 0;
+    }
+    for(int i = 0 ; i < SECTOR_SIZE ; i++){
+        if((unsigned char)buffer[i] != 0xFF){
+            printf("%c", (unsigned char)buffer[i]);
+        }
+        else break;
+    }
+    printf(" ");
+    int spare_num;
+    memcpy(&spare_num, buffer+SECTOR_SIZE, sizeof(int));
+    printf("%d",spare_num);
+    fclose(flashmemoryfp);
+    return 0;
+}
+int ftl_erase(char* flashfile, int pbn, char buffer[]){
+    flashmemoryfp = fopen(flashfile, "rb+");
+    if(!flashmemoryfp){
+        fprintf(stderr, "파일을 열지 못했습니다.\n");
+        return -1;
+    }
+
+    if(fdd_erase(pbn)<0){
+        fprintf(stderr, "삭제에 실패하였습니다.\n");
+        fclose(flashmemoryfp);
+        return -1;
+    }
+
+    fclose(flashmemoryfp);
+    return 0;
+}
+int inplace_update(char *flashfile, int ppn, char *sectordata, int sparedata, char pagebuf[], char* blockbuf){
+    flashmemoryfp = fopen(flashfile, "rb+");
+    if(!flashmemoryfp){
+        fprintf(stderr,"파일을 열지 못했습니다.\n");
+        return -1;
+    }
+    //전체 블록개수 구하기
+    struct stat st;
+    if(stat(flashfile, &st) != 0 ){
+        fprintf(stderr,"파일크기조회실패.\n");
+        fclose(flashmemoryfp);
+        return -1;
+    }
+    int empty_pbn = -1;
+    int num_blocks = st.st_size / BLOCK_SIZE;
+    // 빈 블럭 찾기
+    for(int pbn = 0 ; pbn < num_blocks ; pbn++){
+        fseek(flashmemoryfp, BLOCK_SIZE*pbn, SEEK_SET);
+        if(fread((void *)blockbuf, BLOCK_SIZE, 1, flashmemoryfp)!=1){
+            fprintf(stderr, "빈블럭 읽기 실패\n");
+            fclose(flashmemoryfp);
+            return -1;
+        }
+        int flag = 0;
+        for(int i = 0 ; i < BLOCK_SIZE ; i++){
+            if((unsigned char)blockbuf[i] != 0xFF){
+                flag = 1;
+                break;
+            }
+        }
+        if(flag == 1) continue;
+        else{
+            empty_pbn = pbn;
+            break;
+        }
+    }
+    if(empty_pbn == -1){
+        fprintf(stderr, "빈 블록을 찾지 못했습니다.\n");
+        fclose(flashmemoryfp);
+        return -1;
+    }
+    int target_pbn = ppn / PAGE_NUM;
+    int target_offset = ppn % PAGE_NUM;
+
+    int read_cnt = 0;
+    int write_cnt = 0;
+    int erase_cnt = 0;
+    int empty_block_flag = 1;   //copy시 빈블록으로 아무내용도 복사하지 않았다면 1, 불필요한 erase차단 목적
+    //빈 block로 복사
+    for(int i = 0 ; i < PAGE_NUM ; i++){
+        // 덮어쓸 위치면 복사 x
+        if(i == target_offset) continue;
+        fdd_read(target_pbn*PAGE_NUM + i, pagebuf);
+        read_cnt++;
+        int flag = 0;
+        for(int i = 0 ; i < PAGE_SIZE ; i++){
+            if((unsigned char)pagebuf[i] != 0xFF){
+                flag = 1;
+                break;
+            }
+        }
+        if(!flag){
+            continue;
+        }
+        fdd_write(empty_pbn*PAGE_NUM + i, pagebuf);
+        write_cnt++;
+    }
+    //기존 block erase
+    fdd_erase(ppn/PAGE_NUM);
+    erase_cnt++;
+    // 수정 page포함 기존 위치에 복사
+    for(int i = 0 ; i < PAGE_NUM ; i++){
+        // 덮어쓸 위치면 입력값 복사
+        if(i == target_offset){
+            memset(pagebuf, 0xFF, PAGE_SIZE);
+            int len = strlen(sectordata);
+            memcpy(pagebuf, sectordata, len);
+            memcpy(pagebuf+SECTOR_SIZE, &sparedata, sizeof(int));
+            fdd_write(ppn, pagebuf);
+            write_cnt++;
+            continue;
+        }
+        fdd_read(empty_pbn*PAGE_NUM + i, pagebuf);
+        int flag = 0;
+        for(int i = 0 ; i < PAGE_SIZE ; i++){
+            if((unsigned char)pagebuf[i] != 0xFF){
+                flag = 1;
+                break;
+            }
+        }
+        if(!flag){
+            continue;
+        }
+        empty_block_flag = 0;
+        read_cnt++;
+        fdd_write(target_pbn*PAGE_NUM + i, pagebuf);
+        write_cnt++;
+    }
+    if(!empty_block_flag){
+        // 빈 block 초기화
+        fdd_erase(empty_pbn);
+        erase_cnt++;
+    }
+    //횟수 출력
+    printf("#reads=%d #writes=%d #erases=%d\n",read_cnt,write_cnt,erase_cnt);
+    fclose(flashmemoryfp);
+    return 0;
+}
+int main(int argc, char *argv[])
+{	
+	char sectorbuf[SECTOR_SIZE];
+	char pagebuf[PAGE_SIZE];
+	char *blockbuf=malloc(BLOCK_SIZE);
+	
+	// flash memory 파일 생성: 위에서 선언한 flashmemoryfp를 사용하여 플래시 메모리 파일을 생성한다. 그 이유는 fdevicedriver.c에서 
+	//                 flashmemoryfp 파일포인터를 extern으로 선언하여 사용하기 때문이다.
+	// 페이지 쓰기: pagebuf의 섹터와 스페어에 각각 입력된 데이터를 정확히 저장하고 난 후 해당 인터페이스를 호출한다
+	// 페이지 읽기: pagebuf를 인자로 사용하여 해당 인터페이스를 호출하여 페이지를 읽어 온 후 여기서 섹터 데이터와
+	//                  스페어 데이터를 분리해 낸다
+	// memset(), memcpy() 등의 함수를 이용하면 편리하다. 물론, 다른 방법으로 해결해도 무방하다.
+    char option = argv[1][0];
+    switch (option){
+        // flashmem emulator
+        case 'c':
+            if (argc != 4){
+                fprintf(stderr, "%s c <flashfile> <#blocks> 형식에 맞지 않습니다. \n",argv[0]);
+                return -1;
+            }
+            return flash_memory_emulator(argv[2], atoi(argv[3]));
+        
+        // page write
+        case 'w':
+            if (argc != 6){
+                fprintf(stderr, "%s w <flashfile> <ppn> \"<sectordata>\" \"<sparedata>\" 형식에 맞지 않습니다. \n",argv[0]);
+                return -1;
+            }
+            return ftl_write(argv[2], atoi(argv[3]), argv[4], atoi(argv[5]), pagebuf); 
+           
+        // page read
+        case 'r':
+            if (argc != 4){
+                fprintf(stderr, "%s r <flashfile> <ppn> 형식에 맞지 않습니다. \n",argv[0]);
+                return -1;
+            }
+            return ftl_read(argv[2], atoi(argv[3]), pagebuf); 
+      
+        // block erase
+        case 'e':
+            if (argc != 4){
+                fprintf(stderr, "%s e <flashfile> <pbn> 형식에 맞지 않습니다. \n",argv[0]);
+                return -1;
+            }
+            return ftl_erase(argv[2], atoi(argv[3]), pagebuf); 
+        
+        // inplace update
+        case 'u':
+            if (argc != 6){
+                fprintf(stderr, "%s u <flashfile> <ppn> \"<sectordata>\" \"<sparedata>\" 형식에 맞지 않습니다. \n",argv[0]);
+                return -1;
+            }
+            return inplace_update(argv[2], atoi(argv[3]), argv[4], atoi(argv[5]), pagebuf, blockbuf);
+        default:
+            fprintf(stderr, "잘못된 옵션입니다.\n");
+            return -1;
+    }
+	return 0;
+}


### PR DESCRIPTION
# 과제 2: Flash Device Driver 활용
## 1. 개요 
- “Flash Memory” 강의에서 배운 Flash device driver에 대한 이해를 높이고 이를 활용하는 프로그램을 구현하며, 다음과 같은 제약 사항을 따라야 한다.
- 파일 I/O 연산은 system call 또는 C 라이브러리만을 사용한다.
- 아래의 (1), (2), (3), (4), (5)의 기능을 ftlmgr.c에 구현한다.
- 아래 (2), (3), (4), (5)의 기능은 fdevicedriver.c의 인터페이스를 이용하여 구현한다.- fdevicedriver.c는 주어진 그대로 사용하며 수정해서는 안된다.

### (1) flash memory emulator
 Flash memory 저장 장치를 모방하는 flash memory 파일을 생성한다. 여기에는 n개의 블록과 각 블록에 m개의 페이지가 존재하며, 각 페이지는 하나의 512B 섹터영역(sector)과 16B 스페어영역(spare)으로 구성된다. 또한 블록은 8개의 페이지로 이루어져 있다 (즉, m=8). 아래의 명령어를 실행시키면 블록의 수 <#blocks>로 구성되는 flash memory 파일 <flashfile>을 생성한다. 

_a.out c <flashfile> <#blocks>_

**<예시>**
_a.out c flashmemory 10_

옵션으로 c를 사용하며, 10개의 블록과 각 블록은 8개의 물리적 페이지로 구성되는 flashmemory 파일을 생성한다 (파일 크기: 10*8*(512+16)=42,240B). 이때 모든 페이지의 모든 바이트는 0xFF로 초기화한다 (파일 전체를 0xFF로 채운다). Flash memory에서 ‘erase’ 연산도 결국 초기화 작업이기 때문에 파일에서 0xFF로 초기화하는 방법은 fdevicedriver.c의 fdd_erase() 함수를 활용하거나 참고하여 프로그래밍한다.

**<주의>**
- 생성한 flash memory 파일은 아래 (2), (3), (4)에서 사용한다.

### (2) 페이지 쓰기
Flash memory 저장장치에 페이지 단위로 데이터 쓰기를 수행한다. 아래 명령어를 실행시키면 <flashfile> 파일의 <ppn>의 물리적 페이지 번호를 가지는 페이지에, 섹터영역에는 <sectordata>를 스페어영역에는 <sparedata>를 저장한다. 만약 <flashfile>의 블록의 수가 10이고 페이지 수가 8이면 ppn=0, 1, 2, ..., 79가 된다. 실제 <sectordata>와 <sparedata>는 각각 512B와 16B가 되어야 하나 화면상에서 입력하기 어려우므로 그 크기가 작아도. 실행 결과를 화면에 출력할 필요가 없다.
_a.out w <flashfile> <ppn> <sectordata> <sparedata>_

**<예시>**
 _a.out w flashmemory 5 “abcd12345@%$” “12”_

옵션으로 w를 사용하며, ppn=5 즉, 6번째 페이지에 큰따옴표로 묶여있는 abcd12345@%$를 저장한다. 주어진 flashmemory 파일은 이미 생성되어 있어야 하며, 이 파일에는 최소한 6개의 페이지가 존재해야 한다. 주어진 섹터데이터를 해당 페이지의 섹터영영에 처음부터 차례로 저장한다. 만약 주어진 섹터데이터가 512B보다 적을 경우 나머지 공간은 0xFF로 채운다. abcd12345@%$를 6번째 페이지의 섹터영역에 처음부터 채우고 나머지 500B는 0xFF로 채운다. 스페어의 경우도 이와 같은 방식으로 처리한다.

**<주의>**
- <sectordata>와 <sparedata>는 blank를 포함할 수 있기 때문에 큰따옴표로 데이터를 
묶어서 입력한다. 그렇지 않는 경우 채점 시 정상적으로 동작하지 않는다.
- 섹터 데이터와 스페어 데이터는 키보드로 입력할 수 있는 문자로 표현한다.
- 이 명령어로는 동일한 페이지에 새로운 데이터로 갱신할 수 없다 (갱신을 위해서는 (5) 명령어를 사용해야 함).
- <sparedata>는 정수가 사용되며, 따라서 스페어영역에 저장할 때 반드시 4Byte “binary integer” 모드로 저장한다.

### (3) 페이지 읽기
(주의: ASCII character 모드가 아님)
 Flash memory 저장장치에서 페이지 단위로 읽기를 수행한다. 아래 명령어를 실행시키면 <flashfile> 파일의 <ppn>의 물리적 페이지 번호를 가지는 페이지에 저장되어 있는 섹터 데이터와 스페어 데이터를 화면에 출력한다.

 _a.out r <flashfile> <ppn>_
 
**<예시>**
 _a.out r flashmemory 5_
 _abcd12345@%$ 12_

옵션으로 r를 사용하며, flashmemory 파일의 ppn=5 페이지에서 섹터영역의 데이터와 스페어영역의 데이터를 읽어서 화면에 출력한다. 위의 (2)의 예시와 같이 데이터를 저장하였다고 가정한 것이며, 섹터 데이터는 스페어영역에서 첫 번째 0xFF 전까지의 의미있는 데이터를,스페어 데이터는 스페어영역에서 첫 4B의 정수값을 각각 출력한다.

**<주의>**
- 읽어야 할 페이지의 섹터영역에 의미있는 데이터가 존재하지 않는 경우 (섹터에 0xFF만 저장되어 있는 경우) 화면에 아무것도 출력할 필요가 없다.

### (4) 블록 소거(erase)
 Flash memory 저장장치에서 블록 단위로 블록 소거를 수행한다. 아래 명령어를 실행시키면 <flashfile> 파일의 <pbn>의 물리적 블록번호를 가지는 블록을 소거한다. 화면에 실행 결과를 출력할 필요가 없다.
 
_a.out e <flashfile> <pbn>_

 **<예시>**
 _a.out e flashmemory 3_

옵션 e를 사용하며, flashmemory 파일의 pbn=3 즉, 4번째 블록을 소거한다. 

### (5) In-place update
위의 (2)에서 구현한 페이지 쓰기 명령어를 이용하여 Flash memory에 여러 번의 쓰기를 수행했다고 가정할 때, 이미 데이터가 존재하는 페이지에 갱신(update)이 발생하면 강의자료처럼 in-place update를 수행한다. 강의자료처럼 해당 블록의 정상적인 페이지를 다른 페이지에 복사(copy)할 때 반드시 빈 블록을 하나 할당받아서 복사하는 제약을 둔다. 아래 명령어를 실행시키면 <flashfile> 파일의 <ppn> 번호의 페이지에 새로운 데이터 <sectordata>와 <sparedata>으로 갱신한다. 

_a.out u <flashfile> <ppn> <sectordata> <sparedata>_

 **<예시>**
 _a.out u flashmemory 11 “abcd6789@%$” “30”_
 _#reads=8 #writes=5 #erases=2_
옵션으로 u를 사용하며, flashmemory 파일의 ppn=11 즉, 12번째 페이지의 섹터영역과 스페어영역을 각각 abcd6789@%$와 30으로 갱신한다. 갱신하는 절차는 강의자료를 따른다. 갱신을 수행하는 과정에서 최소한의 읽기, 쓰기, 소거의 횟수를 각각 화면에 출력한다.
 
**<주의>**
- <sectordata>와 <sparedata>는 blank를 포함할 수 있으므로 큰따옴표로 데이터를 묶어서 입력한다. 그렇지 않는 경우 채점 시 정상적으로 동작하지 않는다.
- 섹터 데이터와 스페어 데이터는 키보드로 입력할 수 있는 문자로 표현한다.
- 이 명령어를 이용하여 동일한 페이지에 여러 번 갱신을 수행할 수 있다.
- <sparedata>는 정수가 사용되며, 따라서 스페어영역에 저장할 때 반드시 4Byte “binary integer” 모드로 저장한다.
 (주의: ASCII character 모드로 저장하지 말 것)- 반드시 위의 예시와 같이 출력 포맷을 따라야 한다.